### PR TITLE
feat: Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,42 @@ These entry points are routed through the CLI file (`aip_site/cli.py`); when
 this application is installed using pip, it makes the `aip-site-gen`
 (publisher) and `aip-site-serve` (server) commands available.
 
+### Extensions
+
+This site generator includes a basic extension system for AIPs. When processing
+AIPs as plain Markdown files, it will make any Markdown (level 2 or 3) header
+into a block. Therefore...
+
+```md
+## Foo bar baz
+
+Lorem ipsum dolor set amet
+```
+
+Becomes...
+
+```j2
+{% block foo_bar_baz %}
+## Foo bar baz
+
+Lorem ipsum dolor set amet
+{% endblock %}
+```
+
+That allows an overriding template to extend the original one and override
+sections:
+
+```j2
+{% extends aip.templates.generic %}
+
+{% block foo_bar_baz %}
+
+## My mo-betta foo bar baz
+
+Lorem ipsum dolor set something-not-amet
+{% endblock %}
+```
+
 [dataclasses]: https://docs.python.org/3/library/dataclasses.html
 [jekyll]: https://jekyllrb.com/
 [jinja2]: https://jinja.palletsprojects.com/en/2.11.x/

--- a/aip_site/md.py
+++ b/aip_site/md.py
@@ -18,6 +18,8 @@ import markdown              # type: ignore
 import pymdownx.highlight    # type: ignore
 import pymdownx.superfences  # type: ignore
 
+from aip_site.utils import cached_property
+
 
 class MarkdownDocument(str):
     """A utility class representing Markdown content."""
@@ -38,7 +40,7 @@ class MarkdownDocument(str):
     def __str__(self) -> str:
         return self._content
 
-    @property
+    @cached_property
     def blocked_content(self) -> str:
         """Return a Markdown document with Jinja blocks added per-section."""
         answer = str(self)
@@ -65,14 +67,12 @@ class MarkdownDocument(str):
         # Done; return the answer.
         return answer
 
-    @property
+    @cached_property
     def html(self) -> str:
         """Return the HTML content for this Markdown document."""
-        if not hasattr(self, '_html'):
-            self._html = self._engine.convert(self._content)
-        return self._html
+        return self._engine.convert(self._content)
 
-    @property
+    @cached_property
     def title(self) -> str:
         """Return the document title."""
         return self._content.strip().splitlines()[0].strip('# \n')

--- a/aip_site/md.py
+++ b/aip_site/md.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import markdown              # type: ignore
 import pymdownx.highlight    # type: ignore
 import pymdownx.superfences  # type: ignore
@@ -37,6 +39,33 @@ class MarkdownDocument(str):
         return self._content
 
     @property
+    def blocked_content(self) -> str:
+        """Return a Markdown document with Jinja blocks added per-section."""
+        answer = str(self)
+
+        # We need to fire the html property because conversion may not have
+        # happened yet, and the toc extension requires conversion to occur
+        # first.
+        #
+        # The `html` property caches, so this does not entail any additional
+        # performance hit.
+        self.html
+
+        # We use the Markdown toc plugin to separate the headers and identify
+        # where to put the blocks. Iterate over each toc_token and encapsulate
+        # it in a block.
+        toc_tokens = self._engine.toc_tokens
+        for ix, token in enumerate(toc_tokens):
+            try:
+                next_token = toc_tokens[ix + 1]
+            except IndexError:
+                next_token = None
+            answer = _add_block(answer, token, next_token)
+
+        # Done; return the answer.
+        return answer
+
+    @property
     def html(self) -> str:
         """Return the HTML content for this Markdown document."""
         if not hasattr(self, '_html'):
@@ -59,6 +88,50 @@ class MarkdownDocument(str):
         # performance hit.
         self.html
         return self._engine.toc
+
+
+def _add_block(content: str, toc_token, next_toc_token=None) -> str:
+    # Determine the beginning of the block.
+    heading = '#' * toc_token['level'] + r'\s+' + toc_token['name']
+    match = re.search(heading, content)
+    if not match:
+        return content
+    start_ix = match.span()[0]
+
+    # Determine the end of the block.
+    end_ix = len(content)
+    if next_toc_token:
+        end_h = '#' * next_toc_token['level'] + r'\s+' + next_toc_token['name']
+        match = re.search(end_h, content)
+        if not match:
+            return content
+        end_ix = match.span()[0]
+    elif '{% endblock %}' in content[start_ix:]:
+        # We can match against an {% endblock %} safely because we are
+        # processing "top-down" (e.g. <h2> before <h3>), then beginning-to-end;
+        # this means that encountering an {% endblock %} is guaranteed to be
+        # the endblock for the enclosing block.
+        end_ix = content.index('{% endblock %}', start_ix)
+
+    # Add the block for this heading.
+    block = content[start_ix:end_ix]
+    block_id = toc_token['id'].replace('-', '_')
+    content = content.replace(block, '\n'.join((
+        f'{{% block {block_id} %}}',
+        block,
+        f'{{% endblock %}} {{# {block_id} #}}',
+    )), 1)
+
+    # Iterate over any children to this toc_token and process them.
+    for ix, child in enumerate(toc_token['children']):
+        try:
+            next_child = toc_token['children'][ix + 1]
+        except IndexError:
+            next_child = None
+        content = _add_block(content, child, next_toc_token=next_child)
+
+    # Done; return the content with blocks.
+    return content
 
 
 def _fmt(src: str, lang: str, css_class: str, *args, **kwargs):

--- a/aip_site/models/aip.py
+++ b/aip_site/models/aip.py
@@ -18,6 +18,8 @@ import datetime
 import re
 import typing
 
+import jinja2
+
 from aip_site import md
 from aip_site.env import jinja_env
 from aip_site.utils import cached_property
@@ -29,14 +31,18 @@ class AIP:
     state: str
     created: datetime.date
     scope: Scope
-    body: str
+    templates: typing.Dict[str, jinja2.Template]
     repo_path: str
     config: typing.Dict[str, typing.Any]
     changelog: typing.Set[Change] = dataclasses.field(default_factory=set)
 
     @cached_property
     def content(self) -> md.MarkdownDocument:
-        answer = self.body
+        # Render the content template into the actual content.
+        answer = next(iter(self.templates.values())).render(
+            aip=self,
+            site=self.site,
+        )
 
         # TEMPORARY: In the interest of having two discrete migrations,
         # rewrite the old link style to the new one.

--- a/tests/test_data/aip/general/0031.md
+++ b/tests/test_data/aip/general/0031.md
@@ -29,3 +29,4 @@ author deeply.
 ## Further reading
 
 - For more from Victor Hugo, read AIP-62.
+- For Dickens instead, consult [AIP-43](./0043.md).

--- a/tests/test_data/aip/general/0062/aip.yaml
+++ b/tests/test_data/aip/general/0062/aip.yaml
@@ -1,0 +1,7 @@
+---
+id: 62
+state: approved
+created: 1862-04-21
+placement:
+  category: hugo
+  order: 20

--- a/tests/test_data/aip/general/0062/les-mis.en.md.j2
+++ b/tests/test_data/aip/general/0062/les-mis.en.md.j2
@@ -1,19 +1,7 @@
----
-id: 62
-state: approved
-created: 1862-04-21
-placement:
-  category: hugo
-  order: 20
----
+{% extends aip.templates.generic %}
 
-# Les Misérables
-
-In 1815, M. Charles-François-Bienvenu Myriel was Bishop of Digne He was an old
-man of about seventy-five years of age; he had occupied the see of Digne
-since 1806.
-
-## Guidance
+{% block bp_myriel %}
+## Bishop Myriel
 
 Although this detail has no connection whatever with the real substance of what
 we are about to relate, it will not be superfluous, if merely for the sake of
@@ -29,7 +17,4 @@ parliamentary families. In spite of this marriage, however, it was said that
 Charles Myriel created a great deal of talk. He was well formed, though rather
 short in stature, elegant, graceful, intelligent; the whole of the first
 portion of his life had been devoted to the world and to gallantry.
-
-## Further reading
-
-- For more from Victor Hugo, read [AIP-31](/31).
+{% endblock %}

--- a/tests/test_data/aip/general/0062/les-mis.md
+++ b/tests/test_data/aip/general/0062/les-mis.md
@@ -1,0 +1,43 @@
+# Les Misérables
+
+Les Misérables is a 1862 novel by the French novelist Victor Hugo.
+
+## Guidance
+
+In 1815, M. Charles-François-Bienvenu Myriel was Bishop of Digne. He was an old
+man of about seventy-five years of age; he had occupied the see of Digne
+since 1806.
+
+### Bp. Myriel
+
+Quoique ce détail ne touche en aucune manière au fond même de ce que nous avons
+à raconter, il n'est peut-être pas inutile, ne fût-ce que pour être exact en
+tout, d'indiquer ici les bruits et les propos qui avaient couru sur son compte
+au moment où il était arrivé dans le diocèse. Vrai ou faux, ce qu'on dit des
+hommes tient souvent autant de place dans leur vie et surtout dans leur
+destinée que ce qu'ils font. M. Myriel était fils d'un conseiller au parlement
+d'Aix; noblesse de robe. On contait de lui que son père, le réservant pour
+hériter de sa charge, l'avait marié de fort bonne heure, à dix-huit ou vingt
+ans, suivant un usage assez répandu dans les familles parlementaires. Charles
+Myriel, nonobstant ce mariage, avait, disait-on, beaucoup fait parler de lui.
+Il était bien fait de sa personne, quoique d'assez petite taille, élégant,
+gracieux, spirituel; toute la première partie de sa vie avait été donnée au
+monde et aux galanteries. La révolution survint, les événements se
+précipitèrent, les familles parlementaires décimées, chassées, traquées, se
+dispersèrent. M. Charles Myriel, dès les premiers jours de la révolution,
+émigra en Italie. Sa femme y mourut d'une maladie de poitrine dont elle était
+atteinte depuis longtemps. Ils n'avaient point d'enfants. Que se passa-t-il
+ensuite dans la destinée de M. Myriel? L'écroulement de l'ancienne société
+française, la chute de sa propre famille, les tragiques spectacles de 93, plus
+effrayants encore peut-être pour les émigrés qui les voyaient de loin avec le
+grossissement de l'épouvante, firent-ils germer en lui des idées de renoncement
+et de solitude? Fut-il, au milieu d'une de ces distractions et de ces
+affections qui occupaient sa vie, subitement atteint d'un de ces coups
+mystérieux et terribles qui viennent quelquefois renverser, en le frappant au
+cœur, l'homme que les catastrophes publiques n'ébranleraient pas en le frappant
+dans son existence et dans sa fortune? Nul n'aurait pu le dire; tout ce qu'on
+savait, c'est que, lorsqu'il revint d'Italie, il était prêtre.
+
+## Further reading
+
+- For more from Victor Hugo, read [AIP-31](/31).

--- a/tests/test_data/config/ext.yaml
+++ b/tests/test_data/config/ext.yaml
@@ -1,0 +1,4 @@
+---
+- us
+- en
+- generic

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -69,6 +69,23 @@ def test_blocked_content(markdown_doc):
         assert blocked.index(now) < blocked.index(later)
 
 
+def test_blocked_content_error_boundaries(markdown_doc):
+    # Maliciously screw up the toc since I do not actually know how
+    # to trigger these error cases otherwise.
+    markdown_doc.html
+    markdown_doc._engine.toc_tokens.append({
+        'level': 2,
+        'id': 'missing',
+        'name': 'Missing',
+        'children': [],
+    })
+
+    # Some blocks would actually be added in this situation, but this is
+    # undefined behavior. We just test that we get content back.
+    assert isinstance(markdown_doc.blocked_content, str)
+    assert '### Drilling down' in markdown_doc.blocked_content
+
+
 def test_coerce(markdown_doc):
     assert '# Title' in markdown_doc
     assert '# Title' in str(markdown_doc)
@@ -87,7 +104,7 @@ def test_title(markdown_doc):
     assert markdown_doc.title == 'Title'
 
 
-def toc(markdown_doc):
+def test_toc(markdown_doc):
     assert 'Sub 1' in markdown_doc.toc
     assert 'Drilling down' in markdown_doc.toc
     assert 'Still drilling' in markdown_doc.toc

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -48,6 +48,27 @@ def markdown_doc():
     """).strip())
 
 
+def test_blocked_content(markdown_doc):
+    blocked = markdown_doc.blocked_content
+    blocks = ('sub_1', 'drilling_down', 'still_drilling', 'sub_2')
+    for ix, block in enumerate(blocks):
+        assert f'{{% block {block} %}}' in blocked
+        assert f'{{% endblock %}} {{# {block} #}}' in blocked
+
+    # Also ensure that the blocks both open and close in the correct order.
+    now_or_later = (
+        ('{% block sub_1 %}', '{% block drilling_down %}'),
+        ('{% block sub_1 %}', '{% block still_drilling %}'),
+        ('{% block sub_1 %}', '{% block sub_2 %}'),
+        ('{% endblock %} {# drilling_down #}', '{% block still_drilling %}'),
+        ('{% endblock %} {# drilling_down #}', '{% endblock %} {# sub_1 #}'),
+        ('{% endblock %} {# still_drilling #}', '{% endblock %} {# sub_1 #}'),
+        ('{% endblock %} {# sub_1 #}', '{% endblock %} {# sub_2 #}'),
+    )
+    for now, later in now_or_later:
+        assert blocked.index(now) < blocked.index(later)
+
+
 def test_coerce(markdown_doc):
     assert '# Title' in markdown_doc
     assert '# Title' in str(markdown_doc)

--- a/tests/test_models_aip.py
+++ b/tests/test_models_aip.py
@@ -70,6 +70,17 @@ def test_updated(site):
     assert site.aips[43].updated == date(1844, 12, 25)
 
 
+def test_views(site):
+    les_mis = site.aips[62]
+    kw = {'aip': les_mis, 'site': site}
+    assert 'Quoique ce' in les_mis.templates['generic'].render(**kw)
+    assert 'Quoique ce' not in les_mis.templates['en'].render(**kw)
+    assert 'Although' not in les_mis.templates['generic'].render(**kw)
+    assert 'Although' in les_mis.templates['en'].render(**kw)
+    assert 'Myriel was Bishop' in les_mis.templates['generic'].render(**kw)
+    assert 'Myriel was Bishop' in les_mis.templates['en'].render(**kw)
+
+
 def test_render(site):
     rendered = site.aips[43].render()
     assert '<h1>A Christmas Carol</h1>' in rendered


### PR DESCRIPTION
This adds a basic extension system. How it works is thus:

Basic Markdown files work like they always have. However, the system does some dark magic under the hood and makes any Markdown (level 2 or 3) header into a block. So...

```
# Foo bar baz

Lorem ipsum dolor set amet
```

Becomes...

```jinja2
{% block foo_bar_baz %}
## Foo bar baz

Lorem ipsum dolor set amet
{% endblock %}
```

That allows an overriding template to extend the original one and override sections:

```jinja2
{% extends aip.templates.generic %}

{% block foo_bar_baz %}
## My mo-betta foo bar baz

Lorem ipsum dolor set something-not-amet
{% endblock %}
```

A limitation is that one can only override _entire sections_: I expect we will have other overrides to come, but I expect how we deal with them is by having other override mechanisms (there will be no single one-size-fits-all variant), and this still gives all the power that the old split-file system does.