### PR TITLE
fix: Support Markdown tables.

### DIFF
--- a/aip_site/md.py
+++ b/aip_site/md.py
@@ -23,7 +23,7 @@ class MarkdownDocument(str):
     def __init__(self, content: str, *, toc_title: str = 'Contents'):
         self._content = content
         self._engine = markdown.Markdown(
-            extensions=[_superfences, 'toc'],
+            extensions=[_superfences, 'tables', 'toc'],
             extension_configs={
                 'toc': {
                     'title': toc_title,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='aip-site-generator',
-    version='0.1.1',
+    version='0.1.2',
     license='Apache 2.0',
     author='Luke Sneeringer',
     author_email='lukesneeringer@google.com',


### PR DESCRIPTION
The current [Google AIP-160](https://google.aip.dev/160) already uses them.

Related to googleapis/aip#562.