### PR TITLE
fix: View on GitHub should point to the repo.

### DIFF
--- a/aip_site/support/templates/includes/header.html.j2
+++ b/aip_site/support/templates/includes/header.html.j2
@@ -58,7 +58,7 @@
           </button>
           </form>
         </div>
-        <a href="{{ site.base_url }}" class="glue-button glue-button--high-emphasis">
+        <a href="{{ site.repo_url }}" target="_blank" class="glue-button glue-button--high-emphasis">
           <img src="{{ site.relative_uri }}/assets/images/github.png" class="github-logo">
           View on GitHub
         </a>


### PR DESCRIPTION
Toward aip-dev/google.aip.dev#577.