### PR TITLE
feat: Support [^reviewing] section tag.

### DIFF
--- a/aip_site/models/aip.py
+++ b/aip_site/models/aip.py
@@ -82,6 +82,7 @@ class AIP:
                 TabExtension,
             ],
             loader=loaders.AIPLoader(self),
+            undefined=jinja2.StrictUndefined,
         )
 
     @property
@@ -125,7 +126,9 @@ class AIP:
             with io.open(self.path, 'r') as f:
                 contents = f.read()
             _, body = contents.lstrip('-\n').split('---\n', maxsplit=1)
-            return {'generic': jinja2.Template(body)}
+            return {'generic': jinja2.Template(body,
+                undefined=jinja2.StrictUndefined,
+            )}
 
         # Return a dictionary with all of the templates.
         #

--- a/aip_site/support/assets/js/global.js
+++ b/aip_site/support/assets/js/global.js
@@ -58,6 +58,11 @@ $.when($.ready).then(() => {
       .addClass(`spec-${directive.split(' ')[0]}`);
   }
 
+  // Make "reviewing sections" of approved AIPs show a badge.
+  let reviewing = $('p').filter((_, el) => $(el).text() === '[^reviewing]');
+  reviewing.prev('h3').addClass('reviewing');
+  reviewing.remove();
+
   // Make AIP banners appear in a better spot.
   $('#aip-state-banner').insertAfter('#aip-main h1');
 

--- a/aip_site/support/assets/js/global.js
+++ b/aip_site/support/assets/js/global.js
@@ -59,7 +59,7 @@ $.when($.ready).then(() => {
   }
 
   // Make "reviewing sections" of approved AIPs show a badge.
-  let reviewing = $('p').filter((_, el) => $(el).text() === '[^reviewing]');
+  let reviewing = $('h3 + p').filter((_, el) => $(el).text() === '[^reviewing]');
   reviewing.prev('h3').addClass('reviewing');
   reviewing.remove();
 

--- a/aip_site/support/scss/imports/aip/badges.scss
+++ b/aip_site/support/scss/imports/aip/badges.scss
@@ -16,3 +16,10 @@
   background-color: $glue-yellow-50;
   border: 1px solid $glue-yellow-200;
 }
+
+h3.reviewing::after {
+  @extend .aip-state;
+  @extend .aip-state-reviewing;
+  content: 'Reviewing';
+  font-size: 0.5em;
+}


### PR DESCRIPTION
This adds support for a special syntax to add a "reviewing" badge after an `<h3>`.

The syntax is:

    ### Header

    [^reviewing]

    Lorem ipsum dolor set amet...

This syntax was selected because it mirrors the Markdown footnote syntax and is unlikely to conflict with anything. The actual
transformation is handled in JavaScript for now, rather than the Markdown parser. The Markdown parser would be arguably _better_ but requires significantly more work. This may be refactored in the future.

<img width="800" alt="Screen Shot 2020-10-04 at 2 38 05 PM" src="https://user-images.githubusercontent.com/4346/95027672-3bc6cf00-064f-11eb-8e37-4f3081c9197b.png">
