### PR TITLE
feat: fix page anchor scrolling

### DIFF
--- a/aip_site/support/scss/imports/headings.scss
+++ b/aip_site/support/scss/imports/headings.scss
@@ -4,7 +4,8 @@
   h2,
   h3,
   h4,
-  h5 {
+  h5,
+  a[name] {
     // This creates a "fake block" above the header that does not show up
     // anywhere but tricks the browser into thinking that the anchor is 80px
     // higher than it actually is.


### PR DESCRIPTION
If there is a tag like `<a name="here"><a>` so that you can jump on the page to that point, then the same hack needs to be applied to the anchor as does the one to headings because the page content goes to the top of the page, under the nav bar.