### PR TITLE
chore: fix outline around fake block for anchor

### DIFF
--- a/aip_site/support/scss/imports/headings.scss
+++ b/aip_site/support/scss/imports/headings.scss
@@ -9,6 +9,9 @@
     // This creates a "fake block" above the header that does not show up
     // anywhere but tricks the browser into thinking that the anchor is 80px
     // higher than it actually is.
+    cursor: default;
+    outline: none;
+
     &::before {
       display: block;
       content: ' ';


### PR DESCRIPTION
Fixes a weird css bug where this is an outline around the named anchor when clicking in the "fake block" created to fill space at the top of the page.