### PR TITLE
Removes updated function and section

### DIFF
--- a/aip_site/models/aip.py
+++ b/aip_site/models/aip.py
@@ -150,16 +150,6 @@ class AIP:
         return self.content.title
 
     @property
-    def updated(self):
-        """Return the most recent date on the changelog.
-
-        If there is no changelog, return the created date instead.
-        """
-        if self.changelog:
-            return sorted(self.changelog)[0].date
-        return self.created
-
-    @property
     def _legacy(self) -> bool:
         """Return True if this is a legacy AIP, False otherwise."""
         return self.path.endswith('.md')

--- a/aip_site/support/templates/aip.html.j2
+++ b/aip_site/support/templates/aip.html.j2
@@ -33,7 +33,6 @@ AIP-{{ aip.id }}: {{ aip.title }}
     <tr><td>State</td><td>{{ aip.state | capitalize }}</td></tr>
     {% endif -%}
     <tr><td>Created</td><td>{{ aip.created }}</td></tr>
-    <tr><td>Updated</td><td>{{ aip.updated }}</td></tr>
   </table>
 
   {# Table of contents -#}


### PR DESCRIPTION
https://github.com/aip-dev/site-generator/issues/95 identified that the logic that pulls and sorts the changelog isn't working. Currently, it seems to be returning `None`.

In lieu of fixing the function, this change just removes the `Updated` section from AIPs. Users can use the changelog at the bottom of each page to identify when the page was last updated.

I tested the changes locally.