### PR TITLE
Fix text overflow over sticky sidebar.

### DIFF
--- a/aip_site/support/scss/imports/sidebar.scss
+++ b/aip_site/support/scss/imports/sidebar.scss
@@ -12,6 +12,7 @@
 
   .docs-component-sidebar {
     -webkit-position: sticky;
+    background: #fff;
     display: block;
     float: right;
     position: sticky;


### PR DESCRIPTION
Overflow x content is hidden behind sticky sidebar. Content is visible if scrolled below the the sidebar. Not the best solution, but another one does not come to mind..

## Before

![image](https://github.com/user-attachments/assets/65b1d192-2f3f-4902-a0f0-a4b109698216)

## After

![image](https://github.com/user-attachments/assets/16995ea9-153f-45b0-a835-92c0d9c70d3a)

![image](https://github.com/user-attachments/assets/7a9d6b0d-8f8f-4cf9-a212-eace684481e7)
