### PR TITLE
chore: install pyscss from our fork to bump deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'markupsafe==2.1.1',
         'pygments==2.13.0',
         'pymdown-extensions==9.7',
-        'pyscss==1.4.0',
+        'pyscss @ git+https://github.com/aip-dev/pyScss.git@master',
         'pyyaml==6.0.1',
         'six==1.16.0',
         'types-Markdown==3.4.2.1',


### PR DESCRIPTION
Given that [the pyscss library](https://github.com/Kronuz/pyScss) will not release version 1.4.1 to PyPI ([PR](https://github.com/Kronuz/pyScss/pull/430)), this PR uses our own fork of the repo at master. No changes are needed tpo the upstream original author's repo because the PR to fix the bug was merged, but the one to bump the version was not, and  there was is no new release.

**This is to pave the way to allow us to update outdated dependencies**
